### PR TITLE
fix: use stable github copilot feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "GitHub.copilot-insiders",
+        "GitHub.copilot",
         "dbaeumer.vscode-eslint",
         "DavidAnson.vscode-markdownlint",
         "bierner.markdown-mermaid",


### PR DESCRIPTION
The codespace fails to build when using this feature on stable VSCode (default for codespace users)