### PR TITLE
Add GitHub.copilot-chat to devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
     "vscode": {
       "extensions": [
         "GitHub.copilot",
+        "GitHub.copilot-chat",
         "dbaeumer.vscode-eslint",
         "DavidAnson.vscode-markdownlint",
         "bierner.markdown-mermaid",


### PR DESCRIPTION
This PR adds the GitHub Copilot Chat extension to the devcontainer extensions list.